### PR TITLE
Keep refresh token

### DIFF
--- a/lib/omniauth/strategies/okta.rb
+++ b/lib/omniauth/strategies/okta.rb
@@ -51,8 +51,9 @@ module OmniAuth
 
       def access_token
         ::OAuth2::AccessToken.new(client, oauth2_access_token.token, {
-          :expires_in => oauth2_access_token.expires_in,
-          :expires_at => oauth2_access_token.expires_at
+          :refresh_token => oauth2_access_token.refresh_token,
+          :expires_in    => oauth2_access_token.expires_in,
+          :expires_at    => oauth2_access_token.expires_at
         })
       end
 


### PR DESCRIPTION
Keep the refresh token around if it's returned. It will be in `request.env['omniauth.auth']['credentials']`.